### PR TITLE
Refactor the layout to a two-column design for desktop views.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,331 +21,333 @@
         </header>
 
         <div class="calculator-container">
-            <div class="input-section">
-                <div class="frequency-input">
-                    <label for="frequency">Operating Frequency (MHz):</label>
-                    <input type="number" 
-                           id="frequency" 
-                           step="0.001" 
-                           min="0.1" 
-                           max="10000" 
-                           value="14.074" 
-                           placeholder="e.g., 14.074"
-                           inputmode="decimal"
-                           pattern="[0-9]*[.]?[0-9]+">
-                </div>
-                
-                <div class="antenna-selector">
-                    <label>Antenna Type:</label>
-                    <div class="antenna-buttons">
-                        <button class="antenna-btn active" data-type="vertical">Vertical</button>
-                        <button class="antenna-btn" data-type="dipole">Dipole</button>
-                        <button class="antenna-btn" data-type="yagi">Yagi</button>
-                        <button class="antenna-btn" data-type="quad">Quad</button>
+            <div class="main-content">
+                <div class="input-section">
+                    <div class="frequency-input">
+                        <label for="frequency">Operating Frequency (MHz):</label>
+                        <input type="number"
+                               id="frequency"
+                               step="0.001"
+                               min="0.1"
+                               max="10000"
+                               value="14.074"
+                               placeholder="e.g., 14.074"
+                               inputmode="decimal"
+                               pattern="[0-9]*[.]?[0-9]+">
                     </div>
-                </div>
-            </div>
 
-            <div class="results-section">
-                <div id="vertical-results" class="antenna-results active">
-                    <h3>Vertical Antenna</h3>
-                    <div class="antenna-illustration">
-                        <svg viewBox="0 0 300 200" class="antenna-svg">
-                            <!-- Background -->
-                            <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
-                            
-                            <!-- Ground plane -->
-                            <rect x="0" y="170" width="300" height="30" fill="#E2E8F0"/>
-                            <rect x="0" y="170" width="300" height="5" fill="#94A3B8"/>
-                            
-                            <!-- Vertical element -->
-                            <rect x="145" y="50" width="10" height="120" fill="#3B82F6"/>
-                            <rect x="143" y="45" width="14" height="8" fill="#1E40AF"/>
-                            
-                            <!-- Ground radials -->
-                            <line x1="150" y1="170" x2="80" y2="150" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
-                            <line x1="150" y1="170" x2="220" y2="150" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
-                            <line x1="150" y1="170" x2="60" y2="130" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
-                            <line x1="150" y1="170" x2="240" y2="130" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
-                            
-                            <!-- Feed point -->
-                            <circle cx="150" cy="170" r="8" fill="#EF4444"/>
-                            <circle cx="150" cy="170" r="4" fill="#FFFFFF"/>
-                            
-                            <!-- Coax cable -->
-                            <line x1="150" y1="178" x2="150" y2="195" stroke="#374151" stroke-width="5" stroke-linecap="round"/>
-                            <rect x="140" y="195" width="20" height="8" fill="#6B7280"/>
-                            
-                            <!-- Labels with background -->
-                            <rect x="120" y="25" width="60" height="20" fill="#FFFFFF" rx="10" opacity="0.9"/>
-                            <text x="150" y="38" text-anchor="middle" fill="#1E40AF" font-size="11" font-weight="700">λ/4 Height</text>
-                            
-                            <rect x="125" y="155" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="167" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Feed</text>
-                            
-                            <rect x="110" y="185" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="197" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
-                        </svg>
-                    </div>
-                    <div class="result-grid">
-                        <div class="result-item">
-                            <span class="label">Antenna Height:</span>
-                            <span class="value" id="vertical-height">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Ground Plane Length:</span>
-                            <span class="value" id="vertical-ground">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Impedance:</span>
-                            <span class="value" id="vertical-impedance">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Gain:</span>
-                            <span class="value" id="vertical-gain">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Type:</span>
-                            <span class="value" id="vertical-balun">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Ratio:</span>
-                            <span class="value" id="vertical-balun-ratio">-</span>
+                    <div class="antenna-selector">
+                        <label>Antenna Type:</label>
+                        <div class="antenna-buttons">
+                            <button class="antenna-btn active" data-type="vertical">Vertical</button>
+                            <button class="antenna-btn" data-type="dipole">Dipole</button>
+                            <button class="antenna-btn" data-type="yagi">Yagi</button>
+                            <button class="antenna-btn" data-type="quad">Quad</button>
                         </div>
                     </div>
                 </div>
 
-                <div id="dipole-results" class="antenna-results">
-                    <h3>Dipole Antenna</h3>
-                    <div class="antenna-illustration">
-                        <svg viewBox="0 0 300 200" class="antenna-svg">
-                            <!-- Background -->
-                            <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
-                            
-                            <!-- Support structure -->
-                            <rect x="145" y="25" width="10" height="25" fill="#6B7280"/>
-                            <rect x="140" y="20" width="20" height="8" fill="#374151"/>
-                            
-                            <!-- Left element -->
-                            <line x1="150" y1="50" x2="50" y2="50" stroke="#3B82F6" stroke-width="5" stroke-linecap="round"/>
-                            <circle cx="50" cy="50" r="4" fill="#1E40AF"/>
-                            
-                            <!-- Right element -->
-                            <line x1="150" y1="50" x2="250" y2="50" stroke="#3B82F6" stroke-width="5" stroke-linecap="round"/>
-                            <circle cx="250" cy="50" r="4" fill="#1E40AF"/>
-                            
-                            <!-- Feed point with balun -->
-                            <circle cx="150" cy="50" r="10" fill="#EF4444"/>
-                            <circle cx="150" cy="50" r="5" fill="#FFFFFF"/>
-                            <rect x="145" y="60" width="10" height="25" fill="#DC2626"/>
-                            <rect x="140" y="85" width="20" height="8" fill="#B91C1C"/>
-                            
-                            <!-- Coax cable -->
-                            <line x1="150" y1="93" x2="150" y2="120" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
-                            <rect x="130" y="120" width="40" height="10" fill="#6B7280"/>
-                            
-                            <!-- Support lines -->
-                            <line x1="150" y1="50" x2="150" y2="75" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
-                            
-                            <!-- Labels with background -->
-                            <rect x="35" y="35" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="50" y="47" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Left</text>
-                            
-                            <rect x="235" y="35" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="250" y="47" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Right</text>
-                            
-                            <rect x="125" y="70" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="82" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
-                            
-                            <rect x="110" y="125" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="137" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
-                        </svg>
-                    </div>
-                    <div class="result-grid">
-                        <div class="result-item">
-                            <span class="label">Total Length:</span>
-                            <span class="value" id="dipole-length">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Each Side:</span>
-                            <span class="value" id="dipole-side">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Impedance:</span>
-                            <span class="value" id="dipole-impedance">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Gain:</span>
-                            <span class="value" id="dipole-gain">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Type:</span>
-                            <span class="value" id="dipole-balun">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Ratio:</span>
-                            <span class="value" id="dipole-balun-ratio">-</span>
-                        </div>
-                    </div>
-                </div>
+                <div class="results-section">
+                    <div id="vertical-results" class="antenna-results active">
+                        <h3>Vertical Antenna</h3>
+                        <div class="antenna-illustration">
+                            <svg viewBox="0 0 300 200" class="antenna-svg">
+                                <!-- Background -->
+                                <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
 
-                <div id="yagi-results" class="antenna-results">
-                    <h3>Yagi Antenna</h3>
-                    <div class="antenna-illustration">
-                        <svg viewBox="0 0 300 200" class="antenna-svg">
-                            <!-- Background -->
-                            <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
-                            
-                            <!-- Boom -->
-                            <rect x="25" y="95" width="250" height="6" fill="#6B7280"/>
-                            <rect x="20" y="92" width="260" height="12" fill="#374151" opacity="0.3"/>
-                            
-                            <!-- Reflector (longest) -->
-                            <line x1="50" y1="98" x2="50" y2="45" stroke="#3B82F6" stroke-width="6" stroke-linecap="round"/>
-                            <circle cx="50" cy="45" r="4" fill="#1E40AF"/>
-                            
-                            <!-- Driven element (middle) with feed -->
-                            <line x1="150" y1="98" x2="150" y2="55" stroke="#EF4444" stroke-width="6" stroke-linecap="round"/>
-                            <circle cx="150" cy="55" r="4" fill="#DC2626"/>
-                            
-                            <!-- Director (shortest) -->
-                            <line x1="250" y1="98" x2="250" y2="70" stroke="#3B82F6" stroke-width="6" stroke-linecap="round"/>
-                            <circle cx="250" cy="70" r="4" fill="#1E40AF"/>
-                            
-                            <!-- Feed point with balun -->
-                            <circle cx="150" cy="98" r="8" fill="#EF4444"/>
-                            <circle cx="150" cy="98" r="4" fill="#FFFFFF"/>
-                            <rect x="145" y="106" width="10" height="25" fill="#DC2626"/>
-                            <rect x="140" y="131" width="20" height="8" fill="#B91C1C"/>
-                            
-                            <!-- Coaxial cable -->
-                            <line x1="150" y1="139" x2="150" y2="165" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
-                            <rect x="130" y="165" width="40" height="10" fill="#6B7280"/>
-                            
-                            <!-- Direction arrow -->
-                            <path d="M 250 98 L 280 98 M 275 93 L 280 98 L 275 103" stroke="#F59E0B" stroke-width="4" fill="none" stroke-linecap="round"/>
-                            
-                            <!-- Labels with background -->
-                            <rect x="35" y="30" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="50" y="42" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Reflector</text>
-                            
-                            <rect x="135" y="40" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="52" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Driven</text>
-                            
-                            <rect x="235" y="55" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="250" y="67" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Director</text>
-                            
-                            <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
-                            
-                            <rect x="110" y="170" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="182" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
-                        </svg>
-                    </div>
-                    <div class="result-grid">
-                        <div class="result-item">
-                            <span class="label">Driven Element:</span>
-                            <span class="value" id="yagi-driven">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Reflector:</span>
-                            <span class="value" id="yagi-reflector">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Director:</span>
-                            <span class="value" id="yagi-director">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Boom Length:</span>
-                            <span class="value" id="yagi-boom">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Gain:</span>
-                            <span class="value" id="yagi-gain">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Type:</span>
-                            <span class="value" id="yagi-balun">-</span>
-                        </div>
-                        <div class="result-item">
-                            <span class="label">Balun Ratio:</span>
-                            <span class="value" id="yagi-balun-ratio">-</span>
-                        </div>
-                    </div>
-                </div>
+                                <!-- Ground plane -->
+                                <rect x="0" y="170" width="300" height="30" fill="#E2E8F0"/>
+                                <rect x="0" y="170" width="300" height="5" fill="#94A3B8"/>
 
-                <div id="quad-results" class="antenna-results">
-                    <h3>Quad Antenna</h3>
-                    <div class="antenna-illustration">
-                        <svg viewBox="0 0 300 200" class="antenna-svg">
-                            <!-- Background -->
-                            <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
-                            
-                            <!-- Square loop -->
-                            <rect x="75" y="50" width="150" height="150" fill="none" stroke="#3B82F6" stroke-width="5" rx="8"/>
-                            <rect x="70" y="45" width="160" height="160" fill="none" stroke="#1E40AF" stroke-width="2" rx="10" opacity="0.3"/>
-                            
-                            <!-- Support structures -->
-                            <rect x="145" y="30" width="10" height="20" fill="#6B7280"/>
-                            <rect x="140" y="25" width="20" height="8" fill="#374151"/>
-                            <rect x="145" y="150" width="10" height="20" fill="#6B7280"/>
-                            <rect x="140" y="145" width="20" height="8" fill="#374151"/>
-                            
-                            <!-- Feed point with balun -->
-                            <circle cx="150" cy="125" r="8" fill="#EF4444"/>
-                            <circle cx="150" cy="125" r="4" fill="#FFFFFF"/>
-                            <rect x="145" y="133" width="10" height="25" fill="#DC2626"/>
-                            <rect x="140" y="158" width="20" height="8" fill="#B91C1C"/>
-                            
-                            <!-- Coaxial cable -->
-                            <line x1="150" y1="166" x2="150" y2="185" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
-                            <rect x="130" y="185" width="40" height="10" fill="#6B7280"/>
-                            
-                            <!-- Support lines -->
-                            <line x1="150" y1="50" x2="150" y2="30" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
-                            <line x1="150" y1="150" x2="150" y2="170" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
-                            
-                            <!-- Labels with background -->
-                            <rect x="125" y="20" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="32" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
-                            
-                            <rect x="125" y="160" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="172" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
-                            
-                            <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
-                            
-                            <rect x="110" y="190" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="202" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
-                            
-                            <rect x="110" y="40" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                            <text x="150" y="52" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Loop</text>
-                        </svg>
+                                <!-- Vertical element -->
+                                <rect x="145" y="50" width="10" height="120" fill="#3B82F6"/>
+                                <rect x="143" y="45" width="14" height="8" fill="#1E40AF"/>
+
+                                <!-- Ground radials -->
+                                <line x1="150" y1="170" x2="80" y2="150" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
+                                <line x1="150" y1="170" x2="220" y2="150" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
+                                <line x1="150" y1="170" x2="60" y2="130" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
+                                <line x1="150" y1="170" x2="240" y2="130" stroke="#F59E0B" stroke-width="4" stroke-linecap="round"/>
+
+                                <!-- Feed point -->
+                                <circle cx="150" cy="170" r="8" fill="#EF4444"/>
+                                <circle cx="150" cy="170" r="4" fill="#FFFFFF"/>
+
+                                <!-- Coax cable -->
+                                <line x1="150" y1="178" x2="150" y2="195" stroke="#374151" stroke-width="5" stroke-linecap="round"/>
+                                <rect x="140" y="195" width="20" height="8" fill="#6B7280"/>
+
+                                <!-- Labels with background -->
+                                <rect x="120" y="25" width="60" height="20" fill="#FFFFFF" rx="10" opacity="0.9"/>
+                                <text x="150" y="38" text-anchor="middle" fill="#1E40AF" font-size="11" font-weight="700">λ/4 Height</text>
+
+                                <rect x="125" y="155" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="167" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Feed</text>
+
+                                <rect x="110" y="185" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="197" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
+                            </svg>
+                        </div>
+                        <div class="result-grid">
+                            <div class="result-item">
+                                <span class="label">Antenna Height:</span>
+                                <span class="value" id="vertical-height">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Ground Plane Length:</span>
+                                <span class="value" id="vertical-ground">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Impedance:</span>
+                                <span class="value" id="vertical-impedance">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Gain:</span>
+                                <span class="value" id="vertical-gain">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Type:</span>
+                                <span class="value" id="vertical-balun">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Ratio:</span>
+                                <span class="value" id="vertical-balun-ratio">-</span>
+                            </div>
+                        </div>
                     </div>
-                    <div class="result-grid">
-                        <div class="result-item">
-                            <span class="label">Loop Perimeter:</span>
-                            <span class="value" id="quad-perimeter">-</span>
+
+                    <div id="dipole-results" class="antenna-results">
+                        <h3>Dipole Antenna</h3>
+                        <div class="antenna-illustration">
+                            <svg viewBox="0 0 300 200" class="antenna-svg">
+                                <!-- Background -->
+                                <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
+
+                                <!-- Support structure -->
+                                <rect x="145" y="25" width="10" height="25" fill="#6B7280"/>
+                                <rect x="140" y="20" width="20" height="8" fill="#374151"/>
+
+                                <!-- Left element -->
+                                <line x1="150" y1="50" x2="50" y2="50" stroke="#3B82F6" stroke-width="5" stroke-linecap="round"/>
+                                <circle cx="50" cy="50" r="4" fill="#1E40AF"/>
+
+                                <!-- Right element -->
+                                <line x1="150" y1="50" x2="250" y2="50" stroke="#3B82F6" stroke-width="5" stroke-linecap="round"/>
+                                <circle cx="250" cy="50" r="4" fill="#1E40AF"/>
+
+                                <!-- Feed point with balun -->
+                                <circle cx="150" cy="50" r="10" fill="#EF4444"/>
+                                <circle cx="150" cy="50" r="5" fill="#FFFFFF"/>
+                                <rect x="145" y="60" width="10" height="25" fill="#DC2626"/>
+                                <rect x="140" y="85" width="20" height="8" fill="#B91C1C"/>
+
+                                <!-- Coax cable -->
+                                <line x1="150" y1="93" x2="150" y2="120" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
+                                <rect x="130" y="120" width="40" height="10" fill="#6B7280"/>
+
+                                <!-- Support lines -->
+                                <line x1="150" y1="50" x2="150" y2="75" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
+
+                                <!-- Labels with background -->
+                                <rect x="35" y="35" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="50" y="47" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Left</text>
+
+                                <rect x="235" y="35" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="250" y="47" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Right</text>
+
+                                <rect x="125" y="70" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="82" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
+
+                                <rect x="110" y="125" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="137" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
+                            </svg>
                         </div>
-                        <div class="result-item">
-                            <span class="label">Side Length:</span>
-                            <span class="value" id="quad-side">-</span>
+                        <div class="result-grid">
+                            <div class="result-item">
+                                <span class="label">Total Length:</span>
+                                <span class="value" id="dipole-length">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Each Side:</span>
+                                <span class="value" id="dipole-side">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Impedance:</span>
+                                <span class="value" id="dipole-impedance">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Gain:</span>
+                                <span class="value" id="dipole-gain">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Type:</span>
+                                <span class="value" id="dipole-balun">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Ratio:</span>
+                                <span class="value" id="dipole-balun-ratio">-</span>
+                            </div>
                         </div>
-                        <div class="result-item">
-                            <span class="label">Impedance:</span>
-                            <span class="value" id="quad-impedance">-</span>
+                    </div>
+
+                    <div id="yagi-results" class="antenna-results">
+                        <h3>Yagi Antenna</h3>
+                        <div class="antenna-illustration">
+                            <svg viewBox="0 0 300 200" class="antenna-svg">
+                                <!-- Background -->
+                                <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
+
+                                <!-- Boom -->
+                                <rect x="25" y="95" width="250" height="6" fill="#6B7280"/>
+                                <rect x="20" y="92" width="260" height="12" fill="#374151" opacity="0.3"/>
+
+                                <!-- Reflector (longest) -->
+                                <line x1="50" y1="98" x2="50" y2="45" stroke="#3B82F6" stroke-width="6" stroke-linecap="round"/>
+                                <circle cx="50" cy="45" r="4" fill="#1E40AF"/>
+
+                                <!-- Driven element (middle) with feed -->
+                                <line x1="150" y1="98" x2="150" y2="55" stroke="#EF4444" stroke-width="6" stroke-linecap="round"/>
+                                <circle cx="150" cy="55" r="4" fill="#DC2626"/>
+
+                                <!-- Director (shortest) -->
+                                <line x1="250" y1="98" x2="250" y2="70" stroke="#3B82F6" stroke-width="6" stroke-linecap="round"/>
+                                <circle cx="250" cy="70" r="4" fill="#1E40AF"/>
+
+                                <!-- Feed point with balun -->
+                                <circle cx="150" cy="98" r="8" fill="#EF4444"/>
+                                <circle cx="150" cy="98" r="4" fill="#FFFFFF"/>
+                                <rect x="145" y="106" width="10" height="25" fill="#DC2626"/>
+                                <rect x="140" y="131" width="20" height="8" fill="#B91C1C"/>
+
+                                <!-- Coaxial cable -->
+                                <line x1="150" y1="139" x2="150" y2="165" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
+                                <rect x="130" y="165" width="40" height="10" fill="#6B7280"/>
+
+                                <!-- Direction arrow -->
+                                <path d="M 250 98 L 280 98 M 275 93 L 280 98 L 275 103" stroke="#F59E0B" stroke-width="4" fill="none" stroke-linecap="round"/>
+
+                                <!-- Labels with background -->
+                                <rect x="35" y="30" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="50" y="42" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Reflector</text>
+
+                                <rect x="135" y="40" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="52" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Driven</text>
+
+                                <rect x="235" y="55" width="30" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="250" y="67" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Director</text>
+
+                                <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
+
+                                <rect x="110" y="170" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="182" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
+                            </svg>
                         </div>
-                        <div class="result-item">
-                            <span class="label">Gain:</span>
-                            <span class="value" id="quad-gain">-</span>
+                        <div class="result-grid">
+                            <div class="result-item">
+                                <span class="label">Driven Element:</span>
+                                <span class="value" id="yagi-driven">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Reflector:</span>
+                                <span class="value" id="yagi-reflector">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Director:</span>
+                                <span class="value" id="yagi-director">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Boom Length:</span>
+                                <span class="value" id="yagi-boom">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Gain:</span>
+                                <span class="value" id="yagi-gain">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Type:</span>
+                                <span class="value" id="yagi-balun">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Ratio:</span>
+                                <span class="value" id="yagi-balun-ratio">-</span>
+                            </div>
                         </div>
-                        <div class="result-item">
-                            <span class="label">Balun Type:</span>
-                            <span class="value" id="quad-balun">-</span>
+                    </div>
+
+                    <div id="quad-results" class="antenna-results">
+                        <h3>Quad Antenna</h3>
+                        <div class="antenna-illustration">
+                            <svg viewBox="0 0 300 200" class="antenna-svg">
+                                <!-- Background -->
+                                <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
+
+                                <!-- Square loop -->
+                                <rect x="75" y="50" width="150" height="150" fill="none" stroke="#3B82F6" stroke-width="5" rx="8"/>
+                                <rect x="70" y="45" width="160" height="160" fill="none" stroke="#1E40AF" stroke-width="2" rx="10" opacity="0.3"/>
+
+                                <!-- Support structures -->
+                                <rect x="145" y="30" width="10" height="20" fill="#6B7280"/>
+                                <rect x="140" y="25" width="20" height="8" fill="#374151"/>
+                                <rect x="145" y="150" width="10" height="20" fill="#6B7280"/>
+                                <rect x="140" y="145" width="20" height="8" fill="#374151"/>
+
+                                <!-- Feed point with balun -->
+                                <circle cx="150" cy="125" r="8" fill="#EF4444"/>
+                                <circle cx="150" cy="125" r="4" fill="#FFFFFF"/>
+                                <rect x="145" y="133" width="10" height="25" fill="#DC2626"/>
+                                <rect x="140" y="158" width="20" height="8" fill="#B91C1C"/>
+
+                                <!-- Coaxial cable -->
+                                <line x1="150" y1="166" x2="150" y2="185" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
+                                <rect x="130" y="185" width="40" height="10" fill="#6B7280"/>
+
+                                <!-- Support lines -->
+                                <line x1="150" y1="50" x2="150" y2="30" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
+                                <line x1="150" y1="150" x2="150" y2="170" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
+
+                                <!-- Labels with background -->
+                                <rect x="125" y="20" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="32" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
+
+                                <rect x="125" y="160" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="172" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
+
+                                <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
+
+                                <rect x="110" y="190" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="202" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
+
+                                <rect x="110" y="40" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                <text x="150" y="52" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Loop</text>
+                            </svg>
                         </div>
-                        <div class="result-item">
-                            <span class="label">Balun Ratio:</span>
-                            <span class="value" id="quad-balun-ratio">-</span>
+                        <div class="result-grid">
+                            <div class="result-item">
+                                <span class="label">Loop Perimeter:</span>
+                                <span class="value" id="quad-perimeter">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Side Length:</span>
+                                <span class="value" id="quad-side">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Impedance:</span>
+                                <span class="value" id="quad-impedance">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Gain:</span>
+                                <span class="value" id="quad-gain">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Type:</span>
+                                <span class="value" id="quad-balun">-</span>
+                            </div>
+                            <div class="result-item">
+                                <span class="label">Balun Ratio:</span>
+                                <span class="value" id="quad-balun-ratio">-</span>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -6,12 +6,10 @@
 
 /* Force reset for SVG elements */
 svg.antenna-svg {
-    width: 280px !important;
-    height: 224px !important;
-    max-width: 280px !important;
-    max-height: 224px !important;
-    min-width: 280px !important;
-    min-height: 224px !important;
+    width: 100%;
+    height: auto;
+    max-width: 320px;
+    max-height: 256px;
 }
 
 body {
@@ -61,7 +59,7 @@ html {
     background: white;
     border-radius: 20px;
     box-shadow: 0 20px 40px rgba(0,0,0,0.1);
-    overflow: visible;
+    overflow: hidden; /* To contain the border-radius */
 }
 
 .input-section {
@@ -83,7 +81,7 @@ html {
 
 .frequency-input input {
     width: 100%;
-    max-width: 300px;
+    max-width: 100%; /* Changed from 300px */
     padding: 12px 16px;
     border: 2px solid #e2e8f0;
     border-radius: 10px;
@@ -163,19 +161,11 @@ html {
 .antenna-illustration {
     text-align: center;
     margin-bottom: 25px;
-    padding: 30px;
+    padding: 20px; /* Reduced padding */
     background: #ffffff;
     border-radius: 15px;
     border: 1px solid #e2e8f0;
     box-shadow: 0 3px 10px rgba(0,0,0,0.08);
-}
-
-.antenna-svg {
-    width: 280px !important;
-    height: 224px !important;
-    max-width: 280px !important;
-    max-height: 224px !important;
-    filter: none;
 }
 
 .antenna-svg text {
@@ -185,7 +175,7 @@ html {
 
 .result-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); /* Adjusted minmax */
     gap: 18px;
     margin-bottom: 20px;
 }
@@ -214,12 +204,11 @@ html {
 
 .info-section {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* Adjusted minmax */
     gap: 20px;
     padding: 25px;
     background: #f8fafc;
     border-top: 1px solid #e2e8f0;
-    margin-bottom: 20px;
 }
 
 .info-card {
@@ -227,7 +216,7 @@ html {
     padding: 25px;
     border-radius: 12px;
     border: 1px solid #e2e8f0;
-    margin-bottom: 10px;
+    margin-bottom: 0; /* Removed margin */
 }
 
 .info-card h4 {
@@ -262,22 +251,6 @@ html {
 }
 
 /* Mobile-First Responsive Design */
-@media (max-width: 1200px) {
-    .container {
-        max-width: 95%;
-        padding: 15px;
-    }
-    
-    .result-grid {
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    }
-    
-    .antenna-svg {
-        width: 240px;
-        height: 192px;
-    }
-}
-
 @media (max-width: 768px) {
     .container {
         padding: 12px;
@@ -327,11 +300,6 @@ html {
     .calculator-container {
         border-radius: 15px;
         margin: 0 5px;
-    }
-    
-    .antenna-svg {
-        width: 200px;
-        height: 160px;
     }
 }
 
@@ -407,57 +375,48 @@ html {
         margin-bottom: 18px;
     }
     
-    .antenna-svg {
-        width: 180px;
-        height: 144px;
-    }
-    
     .antenna-svg text {
         font-size: 10px;
     }
 }
 
-@media (max-width: 360px) {
-    .header h1 {
-        font-size: 1.4rem;
+/* Desktop Layout */
+@media (min-width: 1024px) {
+    .main-content {
+        display: flex;
+        gap: 0; /* No gap, borders will handle spacing */
     }
-    
-    .header p {
-        font-size: 0.85rem;
+
+    .input-section {
+        flex: 0 0 380px; /* Fixed width for input section */
+        border-right: 1px solid #e2e8f0;
+        border-bottom: none;
+        padding-right: 25px;
     }
-    
-    .input-section,
-    .results-section,
-    .info-section {
-        padding: 12px;
+
+    .results-section {
+        flex: 1 1 auto;
+        padding-left: 25px;
     }
-    
-    .antenna-btn {
-        padding: 10px 14px;
-        font-size: 0.85rem;
-    }
-    
-    .result-item {
-        padding: 12px;
-    }
-    
-    .info-card {
-        padding: 15px;
+
+    .antenna-buttons {
+        flex-direction: column;
+        gap: 12px;
     }
 }
 
-/* Desktop Enhancements */
+/* Larger Desktop Enhancements */
 @media (min-width: 1201px) {
     .container {
         max-width: 1400px;
     }
     
     .result-grid {
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
     
     .info-section {
-        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+        grid-template-columns: repeat(3, 1fr);
     }
     
     .antenna-btn:hover {
@@ -468,22 +427,12 @@ html {
     .calculator-container {
         box-shadow: 0 25px 50px rgba(0,0,0,0.15);
     }
-    
-    .antenna-svg {
-        width: 320px;
-        height: 256px;
-    }
 }
 
 /* Touch Device Optimizations */
 @media (hover: none) and (pointer: coarse) {
-    .antenna-btn {
-        min-height: 44px; /* Minimum touch target size */
-    }
-    
-    .frequency-input input {
-        min-height: 44px;
-        font-size: 16px;
+    .antenna-btn:active {
+        transform: scale(0.98);
     }
     
     .result-item {
@@ -499,35 +448,10 @@ html {
 /* High DPI Display Support */
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
     .antenna-btn {
-        border-width: 1px;
+        border-width: 1.5px;
     }
     
     .result-item {
-        border-left-width: 2px;
-    }
-}
-
-/* Landscape Mobile Optimization */
-@media (max-width: 768px) and (orientation: landscape) {
-    .header {
-        margin-bottom: 20px;
-    }
-    
-    .header h1 {
-        font-size: 1.8rem;
-    }
-    
-    .input-section {
-        padding: 20px 25px;
-    }
-    
-    .antenna-buttons {
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
-    
-    .antenna-btn {
-        flex: 1;
-        min-width: 120px;
+        border-left-width: 3px;
     }
 }


### PR DESCRIPTION
This change introduces a two-column layout for screens wider than 1024px, placing the input controls on the left and the results on the right. This makes better use of horizontal space on desktop and improves the overall user experience.

Changes include:
- Wrapped input and results sections in a new `main-content` div.
- Added CSS flexbox rules to create the two-column layout.
- Adjusted container widths for better responsiveness on large screens.
- Removed `!important` from SVG styling for better CSS hygiene.