### PR TITLE
Fix: Adjust Quad antenna SVG to prevent label cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,48 +279,50 @@
                         <h3>Quad Antenna</h3>
                         <div class="antenna-illustration">
                             <svg viewBox="0 0 300 200" class="antenna-svg">
-                                <!-- Background -->
-                                <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
+                                <g transform="translate(0, -15)">
+                                    <!-- Background -->
+                                    <rect x="0" y="0" width="300" height="200" fill="#F8FAFC" opacity="0.3"/>
 
-                                <!-- Square loop -->
-                                <rect x="75" y="50" width="150" height="150" fill="none" stroke="#3B82F6" stroke-width="5" rx="8"/>
-                                <rect x="70" y="45" width="160" height="160" fill="none" stroke="#1E40AF" stroke-width="2" rx="10" opacity="0.3"/>
+                                    <!-- Square loop -->
+                                    <rect x="75" y="50" width="150" height="150" fill="none" stroke="#3B82F6" stroke-width="5" rx="8"/>
+                                    <rect x="70" y="45" width="160" height="160" fill="none" stroke="#1E40AF" stroke-width="2" rx="10" opacity="0.3"/>
 
-                                <!-- Support structures -->
-                                <rect x="145" y="30" width="10" height="20" fill="#6B7280"/>
-                                <rect x="140" y="25" width="20" height="8" fill="#374151"/>
-                                <rect x="145" y="150" width="10" height="20" fill="#6B7280"/>
-                                <rect x="140" y="145" width="20" height="8" fill="#374151"/>
+                                    <!-- Support structures -->
+                                    <rect x="145" y="30" width="10" height="20" fill="#6B7280"/>
+                                    <rect x="140" y="25" width="20" height="8" fill="#374151"/>
+                                    <rect x="145" y="150" width="10" height="20" fill="#6B7280"/>
+                                    <rect x="140" y="145" width="20" height="8" fill="#374151"/>
 
-                                <!-- Feed point with balun -->
-                                <circle cx="150" cy="125" r="8" fill="#EF4444"/>
-                                <circle cx="150" cy="125" r="4" fill="#FFFFFF"/>
-                                <rect x="145" y="133" width="10" height="25" fill="#DC2626"/>
-                                <rect x="140" y="158" width="20" height="8" fill="#B91C1C"/>
+                                    <!-- Feed point with balun -->
+                                    <circle cx="150" cy="125" r="8" fill="#EF4444"/>
+                                    <circle cx="150" cy="125" r="4" fill="#FFFFFF"/>
+                                    <rect x="145" y="133" width="10" height="25" fill="#DC2626"/>
+                                    <rect x="140" y="158" width="20" height="8" fill="#B91C1C"/>
 
-                                <!-- Coaxial cable -->
-                                <line x1="150" y1="166" x2="150" y2="185" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
-                                <rect x="130" y="185" width="40" height="10" fill="#6B7280"/>
+                                    <!-- Coaxial cable -->
+                                    <line x1="150" y1="166" x2="150" y2="185" stroke="#374151" stroke-width="6" stroke-linecap="round"/>
+                                    <rect x="130" y="185" width="40" height="10" fill="#6B7280"/>
 
-                                <!-- Support lines -->
-                                <line x1="150" y1="50" x2="150" y2="30" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
-                                <line x1="150" y1="150" x2="150" y2="170" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
+                                    <!-- Support lines -->
+                                    <line x1="150" y1="50" x2="150" y2="30" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
+                                    <line x1="150" y1="150" x2="150" y2="170" stroke="#9CA3AF" stroke-width="2" stroke-dasharray="6,6"/>
 
-                                <!-- Labels with background -->
-                                <rect x="125" y="20" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                                <text x="150" y="32" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
+                                    <!-- Labels with background -->
+                                    <rect x="125" y="20" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                    <text x="150" y="32" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
 
-                                <rect x="125" y="160" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                                <text x="150" y="172" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
+                                    <rect x="125" y="160" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                    <text x="150" y="172" text-anchor="middle" fill="#D97706" font-size="10" font-weight="700">Support</text>
 
-                                <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                                <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
+                                    <rect x="125" y="110" width="50" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                    <text x="150" y="122" text-anchor="middle" fill="#DC2626" font-size="10" font-weight="700">Balun</text>
 
-                                <rect x="110" y="190" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                                <text x="150" y="202" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
+                                    <rect x="110" y="190" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                    <text x="150" y="202" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">Coax Cable</text>
 
-                                <rect x="110" y="40" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
-                                <text x="150" y="52" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Loop</text>
+                                    <rect x="110" y="40" width="80" height="18" fill="#FFFFFF" rx="9" opacity="0.9"/>
+                                    <text x="150" y="52" text-anchor="middle" fill="#1E40AF" font-size="10" font-weight="700">Loop</text>
+                                </g>
                             </svg>
                         </div>
                         <div class="result-grid">


### PR DESCRIPTION
This commit wraps the elements of the Quad antenna SVG in a `<g>` tag with a `transform="translate(0, -15)"` attribute. This shifts the entire illustration up by 15px, ensuring that the "Coax Cable" label is fully visible within the SVG's viewBox and is not cut off in the UI.